### PR TITLE
fix: remove duplicate API methods

### DIFF
--- a/odex-report.md
+++ b/odex-report.md
@@ -1,0 +1,82 @@
+# RuneLite Hybrid Codebase Assessment
+
+## Build status
+- `mvn -q -DskipTests clean compile` in `runelite-api` failed resolving `net.runelite:runelite-maven-plugin:1.11.14-SNAPSHOT` from `https://repo.runelite.net`.
+- The module cannot compile until the plugin artifact is installed locally or the repository becomes reachable.
+
+## API/ABI issues addressed
+- **Client.java** contained duplicate `setVar(int, String)` declarations. Consolidated into a single method and marked as a legacy shim.
+- **RuneLiteObject.java** exposed duplicate `getWorldView()` and `setZ(int)` methods. These are now singular deprecated wrappers delegating to the controller.
+
+## Remaining blockers
+- Missing `runelite-maven-plugin` prevents compilation of `runelite-api` and full reactor.
+
+## Suggested patches
+```diff
+--- a/runelite-api/src/main/java/net/runelite/api/Client.java
++++ b/runelite-api/src/main/java/net/runelite/api/Client.java
+@@
+-       /**
+-        * Sets a VarClientString to the passed value
+-        *
+-        * @param var the {@link net.runelite.api.gameval.VarClientID}
+-        * @param value the new value
+-        */
+-       void setVar(int var1, String var2);
++       /** Backport shim for legacy plugins. */
++       @Deprecated
++       void setVar(int var1, String var2);
+@@
+-       /**
+-        * Sets a var value
+-        * @param varIndex the var index
+-        * @param value the value to set
+-        */
+-       void setVar(int varIndex, String value);
+```
+```diff
+--- a/runelite-api/src/main/java/net/runelite/api/RuneLiteObject.java
++++ b/runelite-api/src/main/java/net/runelite/api/RuneLiteObject.java
+@@
+-       @Deprecated
+-       public WorldView getWorldView()
+-       {
+-               return super.getWorldView();
+-       }
+-
+-       @Deprecated
+-       public void setZ(int z)
+-       {
+-               super.setZ(z);
+-       }
+-
+-       public void setZ(int z)
+-       {
+-               super.setZ(z);
+-       }
+-
+-       public WorldView getWorldView()
+-       {
+-               return super.getWorldView();
+-       }
++       /** Backport shim for legacy plugins. */
++       @Deprecated
++       public WorldView getWorldView()
++       {
++               return super.getWorldView();
++       }
++
++       /** Backport shim for legacy plugins. */
++       @Deprecated
++       public void setZ(int z)
++       {
++               super.setZ(z);
++       }
+```
+
+## Checklist
+- [ ] Provide or build `net.runelite:runelite-maven-plugin:1.11.14-SNAPSHOT` locally.
+- [ ] Re-run `mvn -q -pl runelite-api -DskipTests clean compile`.
+- [ ] Once green, run full reactor: `mvn -q -DskipTests clean install`.
+- [ ] Address any subsequent compile errors per module.
+

--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -810,13 +810,9 @@ public interface Client extends OAuthApi, GameEngine
 	 */
 	String getVarcStrValue(@VarCStr int var);
 
-	/**
-	 * Sets a VarClientString to the passed value
-	 *
-	 * @param var the {@link net.runelite.api.gameval.VarClientID}
-	 * @param value the new value
-	 */
-	void setVar(int var1, String var2);
+       /** Backport shim for legacy plugins. */
+       @Deprecated
+       void setVar(int var1, String var2);
 
 	/**
 	 * Sets a VarClientInt to the passed value
@@ -2568,12 +2564,6 @@ public interface Client extends OAuthApi, GameEngine
 	{
 		return 0;
 	}
-	/**
-	 * Sets a var value
-	 * @param varIndex the var index
-	 * @param value the value to set
-	 */
-	void setVar(int varIndex, String value);
 
 	/**
 	 * Sets the menu option count

--- a/runelite-api/src/main/java/net/runelite/api/RuneLiteObject.java
+++ b/runelite-api/src/main/java/net/runelite/api/RuneLiteObject.java
@@ -88,27 +88,19 @@ public class RuneLiteObject extends RuneLiteObjectController
 		this.baseModel = baseModel;
 	}
 
-	@Deprecated
-	public WorldView getWorldView()
-	{
-		return super.getWorldView();
-	}
+       /** Backport shim for legacy plugins. */
+       @Deprecated
+       public WorldView getWorldView()
+       {
+               return super.getWorldView();
+       }
 
-	@Deprecated
-	public void setZ(int z)
-	{
-		super.setZ(z);
-	}
-
-	public void setZ(int z)
-	{
-		super.setZ(z);
-	}
-
-	public WorldView getWorldView()
-	{
-		return super.getWorldView();
-	}
+       /** Backport shim for legacy plugins. */
+       @Deprecated
+       public void setZ(int z)
+       {
+               super.setZ(z);
+       }
 
 	/**
 	 * Sets the location in the scene for the RuneLiteObject


### PR DESCRIPTION
## Summary
- dedupe `Client#setVar` and mark as deprecated backport
- collapse duplicated `RuneLiteObject` shim methods
- capture current build blockers in `odex-report.md`

## Testing
- `mvn -q -DskipTests clean compile` *(fails: Could not transfer net.runelite:runelite-maven-plugin)*
- `mvn -q -DskipTests clean install` *(fails: Could not resolve org.lwjgl:lwjgl-bom 3.3.2)*

------
https://chatgpt.com/codex/tasks/task_e_68992d2ef814832780e2dc96b1de5f96